### PR TITLE
Validationのメモリ使用量削減と高速化

### DIFF
--- a/generator/graph_generator.hpp
+++ b/generator/graph_generator.hpp
@@ -243,6 +243,11 @@ public:
 				1, MPI_INT64_T, MPI_MAX, MPI_COMM_WORLD);
 	}
 
+	int64_t getEdgeMemory(EdgeType** pp_buffer) {
+		*pp_buffer = edge_memory_;
+		return edge_filled_size_;
+	}
+
 	int64_t num_local_edges() { return num_local_edges_; }
 	bool data_is_in_file() { return data_in_file_; }
 	const char* get_filepath() { return filepath_; }

--- a/mpi/benchmark_helper.hpp
+++ b/mpi/benchmark_helper.hpp
@@ -677,7 +677,7 @@ private:
 
 #pragma omp parallel
 		{
-			int* restrict counts = scatter_r.get_counts();
+			int* restrict counts = scatter.get_counts();
 
 #pragma omp for schedule(static)
 			for (int i = 0; i < num_vertexes; ++i) {
@@ -686,9 +686,9 @@ private:
 			} // #pragma omp for schedule(static)
 		}
 
-		scatter_r.sum();
+		scatter.sum();
 
-		send = scatter_r.scatter(vertexes_local);
+		send = scatter.scatter(vertexes_local);
 		
 		free(vertexes_local); vertexes_local = nullptr;
 	}

--- a/mpi/bfs.hpp
+++ b/mpi/bfs.hpp
@@ -123,8 +123,8 @@ public:
 		constructor.construct(edge_list, log_local_verts_unit, graph_);
 	}
 
-         void prepare_bfs(int validation_level, bool pre_exec, bool real_benchmark) {
-                printInformation(validation_level, pre_exec, real_benchmark);
+	void prepare_bfs(int validation_level, bool pre_exec, bool real_benchmark) {
+		printInformation(validation_level, pre_exec, real_benchmark);
 		allocate_memory();
 	}
 

--- a/mpi/graph_constructor.hpp
+++ b/mpi/graph_constructor.hpp
@@ -134,7 +134,7 @@ public:
 		int64_t num_edges = row_starts_[non_zero_rows];
 
 		save("edge_array", edge_array_, num_edges * sizeof(int64_t));
-		save("row_starts", row_starts_, non_zero_rows * sizeof(int64_t));
+		save("row_starts", row_starts_, (non_zero_rows + 1) * sizeof(int64_t));
 		save("isolated_edges", isolated_edges_, non_zero_rows * sizeof(int64_t));
 		
 		free(edge_array_); edge_array_ = NULL;
@@ -162,10 +162,10 @@ public:
 		int64_t src_bitmap_size = local_bitmap_width * mpi.size_2dc;
 		int64_t non_zero_rows = row_sums_[src_bitmap_size];
 
-		row_starts_ = static_cast<int64_t*>(cache_aligned_xcalloc(non_zero_rows * sizeof(int64_t)));
+		row_starts_ = static_cast<int64_t*>(cache_aligned_xcalloc((non_zero_rows + 1) * sizeof(int64_t)));
 		isolated_edges_ = static_cast<int64_t*>(cache_aligned_xcalloc(non_zero_rows * sizeof(int64_t)));
 
-		load("row_starts", row_starts_, non_zero_rows * sizeof(int64_t));
+		load("row_starts", row_starts_, (non_zero_rows + 1) * sizeof(int64_t));
 		load("isolated_edges", isolated_edges_, non_zero_rows * sizeof(int64_t));
 		
 		int64_t num_edges = row_starts_[non_zero_rows];


### PR DESCRIPTION
Validationの処理方法を変更して、メモリ使用量の削減と高速化をしたバージョンです。グラフ構築後、BFS実行前にValidation用データ作成処理が追加されています。そこで一時的にメモリが必要になるので、Validation用データ作成時は、構築済みのグラフデータの一部をファイルに退避する処理を追加しました。

グラフデータの一部をファイルに退避する処理を有効にするには、環境変数 `TMPFILE2` にファイル名を指定してください。

例
```
TMPFILE2=/tmp/graph500tmp
```

ローカルのパスでOKです。一応、共有のパスでも動くように、ファイル名にランク番号を付加しています。書き出したファイルを削除する処理は入っていないので、必要なら実行後に削除してください。環境変数 `TMPFILE2` が指定されていない場合は、グラフデータのファイルへの退避は行われません。

8プロセス、Scale26までしか試していないので、大規模に動かしたときに、本当にメモリ使用量が削減されるのか、Validation
が早くなるのか、不明です。